### PR TITLE
Fix missing 'A' in 'At'

### DIFF
--- a/posts/automated-market-makers-and-liquidity-pools-on-stellar-network/index.md
+++ b/posts/automated-market-makers-and-liquidity-pools-on-stellar-network/index.md
@@ -55,7 +55,7 @@ Two tomatoes will cost 4.26 carrots plus 0.21 carrots in trading fees, and the
 constant sum rises to 20,040.
 This demonstrates an important basic principle – as an asset in the trading pair
 becomes more scarce, our AMM automatically rises its price.
-t the same time, accrued fees increase the size of the pool with each trade.
+At the same time, accrued fees increase the size of the pool with each trade.
 
 The third customer needs carrots. A lot of carrots! He buys 50 carrots for
 30.24 tomatoes + 1.51 in trading fees.


### PR DESCRIPTION
Just a minor fix on this blog post, thanks for sharing!